### PR TITLE
Add Clay in Claude to projects

### DIFF
--- a/content/projects/timeline-projects.ts
+++ b/content/projects/timeline-projects.ts
@@ -9,7 +9,8 @@ export const TimelineProjects: (Omit<
     url: 'https://www.clay.com/blog/clay-in-claude',
     date: new Date('2026-01-26').toISOString(),
     organization: 'clay',
-    description: 'One of the first commercial implementations of the MCP Apps protocol.',
+    description:
+      'One of the first commercial implementations of the MCP Apps protocol.',
   },
   {
     name: 'Clay in ChatGPT',

--- a/content/projects/timeline-projects.ts
+++ b/content/projects/timeline-projects.ts
@@ -5,6 +5,13 @@ export const TimelineProjects: (Omit<
   'isRight' | 'isFirst' | 'isLast' | 'newYear'
 > & { date: string })[] = [
   {
+    name: 'Clay in Claude',
+    url: 'https://www.clay.com/blog/clay-in-claude',
+    date: new Date('2026-01-26').toISOString(),
+    organization: 'clay',
+    description: 'One of the first commercial implementations of the MCP Apps protocol.',
+  },
+  {
     name: 'Clay in ChatGPT',
     url: 'https://www.linkedin.com/posts/grow-with-clay_big-news-clay-is-now-available-directly-activity-7407182915740147712-IPWr',
     date: new Date('2025-12-17').toISOString(),


### PR DESCRIPTION
## Summary
- Adds "Clay in Claude" as a new timeline project, one of the first commercial implementations of the MCP Apps protocol

## Test plan
- [x] `next build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)