### PR TITLE
Add MCP for Sales Reps and Clay CLI, API, and Agent Plugin to projects

### DIFF
--- a/.github/workflows/prettier-check.yml
+++ b/.github/workflows/prettier-check.yml
@@ -17,6 +17,8 @@ jobs:
           key: ${{ runner.os }}-npm-${{ hashFiles('**/workflows/prettier-check.yml') }}
           restore-keys: |
             ${{ runner.os }}-npm-
+      - name: Install modules
+        run: npm ci
       - name: Run prettier
         run: |-
           npx prettier --check .

--- a/content/projects/timeline-projects.ts
+++ b/content/projects/timeline-projects.ts
@@ -5,7 +5,7 @@ export const TimelineProjects: (Omit<
   'isRight' | 'isFirst' | 'isLast' | 'newYear'
 > & { date: string })[] = [
   {
-    name: 'Clay CLI & API',
+    name: 'Clay CLI, API, and Agent Plugin',
     url: 'https://youtu.be/NxIUkh60CcU',
     date: new Date('2026-07-14').toISOString(),
     organization: 'clay',

--- a/content/projects/timeline-projects.ts
+++ b/content/projects/timeline-projects.ts
@@ -5,6 +5,22 @@ export const TimelineProjects: (Omit<
   'isRight' | 'isFirst' | 'isLast' | 'newYear'
 > & { date: string })[] = [
   {
+    name: 'Clay CLI & API',
+    url: 'https://youtu.be/NxIUkh60CcU',
+    date: new Date('2026-07-14').toISOString(),
+    organization: 'clay',
+    description:
+      'Programmatic access to Clay from the terminal, coding agents, and your own services.',
+  },
+  {
+    name: 'MCP for Sales Reps',
+    url: 'https://www.clay.com/blog/mcp-for-reps',
+    date: new Date('2026-07-09').toISOString(),
+    organization: 'clay',
+    description:
+      'Prospect with Clay data and workflows in AI tools like ChatGPT and Claude.',
+  },
+  {
     name: 'Clay in Claude',
     url: 'https://www.clay.com/blog/clay-in-claude',
     date: new Date('2026-01-26').toISOString(),


### PR DESCRIPTION
Adds two new Clay projects to the timeline: MCP for Sales Reps (July 9, 2026, linking to the Clay blog post) and Clay CLI & API (July 14, 2026, linking to the launch video).

🤖 Generated with [Claude Code](https://claude.com/claude-code)