### PR TITLE
Add Dracula Tmux and New Grad Positions to timeline projects

### DIFF
--- a/.github/workflows/prettier-check.yml
+++ b/.github/workflows/prettier-check.yml
@@ -17,6 +17,8 @@ jobs:
           key: ${{ runner.os }}-npm-${{ hashFiles('**/workflows/prettier-check.yml') }}
           restore-keys: |
             ${{ runner.os }}-npm-
+      - name: Install modules
+        run: npm ci
       - name: Run prettier
         run: |-
           npx prettier --check .

--- a/content/projects/timeline-projects.ts
+++ b/content/projects/timeline-projects.ts
@@ -183,8 +183,7 @@ export const TimelineProjects: (Omit<
     date: new Date('2020-05-24').toISOString(),
     description:
       'A collection of full time software engineering, quant, and product management roles for new college graduates.',
-    secondaryDescription:
-      'Now maintained by the team at Simplify with over 17k stars on GitHub.',
+    secondaryDescription: 'Now maintained by the team at Simplify.',
   },
   {
     name: 'Pork Chop',
@@ -208,7 +207,5 @@ export const TimelineProjects: (Omit<
     url: 'https://github.com/dracula/tmux',
     date: new Date('2020-03-14').toISOString(),
     description: 'Official Dracula Theme extension for Tmux.',
-    secondaryDescription:
-      'Grew into one of the most popular Tmux status bar themes, now maintained by over 100 contributors.',
   },
 ];

--- a/content/projects/timeline-projects.ts
+++ b/content/projects/timeline-projects.ts
@@ -182,7 +182,9 @@ export const TimelineProjects: (Omit<
     url: 'https://github.com/SimplifyJobs/New-Grad-Positions',
     date: new Date('2020-05-24').toISOString(),
     description:
-      'A collection of computer science jobs for new college graduates.',
+      'A collection of full time software engineering, quant, and product management roles for new college graduates.',
+    secondaryDescription:
+      'Now maintained by the team at Simplify with over 17k stars on GitHub.',
   },
   {
     name: 'Pork Chop',
@@ -206,5 +208,7 @@ export const TimelineProjects: (Omit<
     url: 'https://github.com/dracula/tmux',
     date: new Date('2020-03-14').toISOString(),
     description: 'Official Dracula Theme extension for Tmux.',
+    secondaryDescription:
+      'Grew into one of the most popular Tmux status bar themes, now maintained by over 100 contributors.',
   },
 ];

--- a/content/projects/timeline-projects.ts
+++ b/content/projects/timeline-projects.ts
@@ -177,6 +177,14 @@ export const TimelineProjects: (Omit<
       'A 4 stage compiler consisting of a scanner, parser, pretty printer, and type checker for the B Minor programming language written with C, Flex, and Bison.',
   },
   {
+    name: 'New Grad Positions',
+    organization: 'personal',
+    url: 'https://github.com/SimplifyJobs/New-Grad-Positions',
+    date: new Date('2020-05-24').toISOString(),
+    description:
+      'A collection of computer science jobs for new college graduates.',
+  },
+  {
     name: 'Pork Chop',
     organization: 'personal',
     url: 'https://github.com/danerwilliams/pork-chop',
@@ -191,5 +199,12 @@ export const TimelineProjects: (Omit<
     date: new Date('2020-04-01').toISOString(),
     description:
       'My original personal website built using Hugo along with customizations using vanilla Javascript and CSS.',
+  },
+  {
+    name: 'Dracula Tmux',
+    organization: 'personal',
+    url: 'https://github.com/dracula/tmux',
+    date: new Date('2020-03-14').toISOString(),
+    description: 'Official Dracula Theme extension for Tmux.',
   },
 ];


### PR DESCRIPTION
Adds the two featured projects to the timeline under the personal (Dane) organization, dated by each repo's initial commit on GitHub: New Grad Positions (May 24, 2020) and Dracula Tmux (March 14, 2020).

🤖 Generated with [Claude Code](https://claude.com/claude-code)