### PR TITLE
Add Charcoal and Clay Agent Plugins as featured projects

### DIFF
--- a/.github/workflows/prettier-check.yml
+++ b/.github/workflows/prettier-check.yml
@@ -17,6 +17,8 @@ jobs:
           key: ${{ runner.os }}-npm-${{ hashFiles('**/workflows/prettier-check.yml') }}
           restore-keys: |
             ${{ runner.os }}-npm-
+      - name: Install modules
+        run: npm ci
       - name: Run prettier
         run: |-
           npx prettier --check .

--- a/components/highlighted-project.tsx
+++ b/components/highlighted-project.tsx
@@ -1,8 +1,9 @@
 import { FC, ReactNode } from 'react';
 import { unreachable } from '../lib/unreachable';
 import { EyeOpenIcon, PersonIcon, StarIcon } from '@radix-ui/react-icons';
+import { GitForkIcon } from './icons/git-fork-icon';
 
-type HighlightedProjectIcon = 'star' | 'eye' | 'person';
+type HighlightedProjectIcon = 'star' | 'eye' | 'person' | 'fork';
 
 interface Stat {
   icon: HighlightedProjectIcon;
@@ -61,6 +62,8 @@ const getIcon = (name: HighlightedProjectIcon) => {
       return <EyeOpenIcon />;
     case 'person':
       return <PersonIcon />;
+    case 'fork':
+      return <GitForkIcon />;
     default:
       return unreachable(name);
   }

--- a/components/icons/git-fork-icon.tsx
+++ b/components/icons/git-fork-icon.tsx
@@ -1,0 +1,24 @@
+import { FC } from 'react';
+
+interface GitForkIconProps {
+  className?: string;
+}
+
+export const GitForkIcon: FC<Readonly<GitForkIconProps>> = ({ className }) => (
+  // Octicons v19.11.0 by GitHub - https://primer.style/octicons License - MIT
+  <svg
+    className={className}
+    width="15"
+    height="15"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 16 16"
+  >
+    <path
+      d="M5 5.372v.878c0 .414.336.75.75.75h4.5a.75.75 0 0 0 .75-.75v-.878a2.25 2.25 0 1 1 1.5 0v.878a2.25 2.25 0 0 1-2.25 2.25h-1.5v2.128a2.251 2.251 0 1 1-1.5 0V8.5h-1.5A2.25 2.25 0 0 1 3.5 6.25v-.878a2.25 2.25 0 1 1 1.5 0ZM5 3.25a.75.75 0 1 0-1.5 0 .75.75 0 0 0 1.5 0Zm6.75.75a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5Zm-3 8.75a.75.75 0 1 0-1.5 0 .75.75 0 0 0 1.5 0Z"
+      fill="currentColor"
+      fillRule="evenodd"
+      clipRule="evenodd"
+    />
+  </svg>
+);

--- a/content/projects/timeline-projects.ts
+++ b/content/projects/timeline-projects.ts
@@ -28,7 +28,7 @@ export const TimelineProjects: (Omit<
     organization: 'cobblestone',
     description:
       'An end to end tenant screening platform with $4M in funding from Y Combinator, a16z, Tishman Speyer (owner of Rockefeller center), and more.',
-    secondaryDescription: 'Shut down in May 2025.',
+    secondaryDescription: 'Acquired by get100.com.',
   },
   {
     name: 'User Management / AuthKit',

--- a/lib/get-github-forks.ts
+++ b/lib/get-github-forks.ts
@@ -1,0 +1,11 @@
+export const getGithubForks = async ({
+  owner,
+  repo,
+}: {
+  owner: string;
+  repo: string;
+}) => {
+  const response = await fetch(`https://api.github.com/repos/${owner}/${repo}`);
+  const data = await response.json();
+  return data.forks_count;
+};

--- a/pages/projects.tsx
+++ b/pages/projects.tsx
@@ -119,9 +119,9 @@ export async function getStaticProps() {
         'I’ve worked on many projects on my own time and for work. Some of these projects are still active and others I no longer work on. This list is not exhaustive.',
       highlightedProjects: [
         {
-          name: 'Clay Agent Plugins',
+          name: 'Clay Agent Plugin',
           url: 'https://github.com/clay-run/agent-plugins',
-          description: "Clay's official plugins for coding agents",
+          description: "Clay's official plugin for coding agents",
           stats: [
             {
               icon: 'star',

--- a/pages/projects.tsx
+++ b/pages/projects.tsx
@@ -12,6 +12,7 @@ import { TimelineProjectProps } from '../components/timeline-project';
 import { TimelineProjects } from '../content/projects';
 import { getRoundedNumber } from '../lib/get-rounded-number';
 import { getGithubStars } from '../lib/get-github-stars';
+import { getGithubForks } from '../lib/get-github-forks';
 import { getGithubContributorsCount } from '../lib/get-github-contributors-count';
 
 interface ProjectsProps {
@@ -51,7 +52,7 @@ const Projects: NextPage<ProjectsProps> = ({
         <PageHeader question="What have I built?" />
         <div className="mt-8">
           <p>{description}</p>
-          <div className="flex flex-row max-[576px]:flex-col gap-6 mt-8">
+          <div className="grid grid-cols-2 max-[576px]:grid-cols-1 gap-6 mt-8">
             {highlightedProjects.map((project) => (
               <div className="flex w-full" key={project.name}>
                 <HighlightedProject {...project} />
@@ -84,6 +85,26 @@ export async function getStaticProps() {
   const draculaTmuxContributorsCount = await getGithubContributorsCount({
     owner: 'dracula',
     repo: 'tmux',
+  });
+
+  const charcoalStars = await getGithubStars({
+    owner: 'danerwilliams',
+    repo: 'charcoal',
+  });
+
+  const charcoalForks = await getGithubForks({
+    owner: 'danerwilliams',
+    repo: 'charcoal',
+  });
+
+  const agentPluginsStars = await getGithubStars({
+    owner: 'clay-run',
+    repo: 'agent-plugins',
+  });
+
+  const agentPluginsForks = await getGithubForks({
+    owner: 'clay-run',
+    repo: 'agent-plugins',
   });
 
   return {
@@ -127,6 +148,36 @@ export async function getStaticProps() {
               label: `${getRoundedNumber(
                 draculaTmuxContributorsCount,
               )} Contributors`,
+            },
+          ],
+        },
+        {
+          name: 'Charcoal',
+          url: 'https://github.com/danerwilliams/charcoal',
+          description: 'A CLI for stacking pull requests, forked from Graphite',
+          stats: [
+            {
+              icon: 'star',
+              label: `${getRoundedNumber(charcoalStars)} Stars`,
+            },
+            {
+              icon: 'fork',
+              label: `${getRoundedNumber(charcoalForks)} Forks`,
+            },
+          ],
+        },
+        {
+          name: 'Clay Agent Plugins',
+          url: 'https://github.com/clay-run/agent-plugins',
+          description: "Clay's official plugins for coding agents",
+          stats: [
+            {
+              icon: 'star',
+              label: `${getRoundedNumber(agentPluginsStars)} Stars`,
+            },
+            {
+              icon: 'fork',
+              label: `${getRoundedNumber(agentPluginsForks)} Forks`,
             },
           ],
         },

--- a/pages/projects.tsx
+++ b/pages/projects.tsx
@@ -119,18 +119,17 @@ export async function getStaticProps() {
         'I’ve worked on many projects on my own time and for work. Some of these projects are still active and others I no longer work on. This list is not exhaustive.',
       highlightedProjects: [
         {
-          name: 'New Grad Positions',
-          url: 'https://github.com/SimplifyJobs/New-Grad-Positions',
-          description:
-            'A collection of computer science jobs for new college graduates',
+          name: 'Clay Agent Plugins',
+          url: 'https://github.com/clay-run/agent-plugins',
+          description: "Clay's official plugins for coding agents",
           stats: [
             {
               icon: 'star',
-              label: `${getRoundedNumber(newGradPositionsStars)} Stars`,
+              label: `${getRoundedNumber(agentPluginsStars)} Stars`,
             },
             {
-              icon: 'eye',
-              label: '10k+ Visits/Day',
+              icon: 'fork',
+              label: `${getRoundedNumber(agentPluginsForks)} Forks`,
             },
           ],
         },
@@ -152,6 +151,22 @@ export async function getStaticProps() {
           ],
         },
         {
+          name: 'New Grad Positions',
+          url: 'https://github.com/SimplifyJobs/New-Grad-Positions',
+          description:
+            'A collection of computer science jobs for new college graduates',
+          stats: [
+            {
+              icon: 'star',
+              label: `${getRoundedNumber(newGradPositionsStars)} Stars`,
+            },
+            {
+              icon: 'eye',
+              label: '10k+ Visits/Day',
+            },
+          ],
+        },
+        {
           name: 'Charcoal',
           url: 'https://github.com/danerwilliams/charcoal',
           description: 'A CLI for stacking pull requests, forked from Graphite',
@@ -163,21 +178,6 @@ export async function getStaticProps() {
             {
               icon: 'fork',
               label: `${getRoundedNumber(charcoalForks)} Forks`,
-            },
-          ],
-        },
-        {
-          name: 'Clay Agent Plugins',
-          url: 'https://github.com/clay-run/agent-plugins',
-          description: "Clay's official plugins for coding agents",
-          stats: [
-            {
-              icon: 'star',
-              label: `${getRoundedNumber(agentPluginsStars)} Stars`,
-            },
-            {
-              icon: 'fork',
-              label: `${getRoundedNumber(agentPluginsForks)} Forks`,
             },
           ],
         },


### PR DESCRIPTION
Adds Charcoal and Clay Agent Plugins as highlighted projects, matching the GitHub pins. The featured section is now a 2-column grid so the four cards wrap into two rows on desktop and keep collapsing to one column on mobile. Both new cards show stars plus forks as the secondary metric (new `getGithubForks` helper and a git fork icon from Octicons). Also updates the Cobblestone timeline note to "Acquired by get100.com."

🤖 Generated with [Claude Code](https://claude.com/claude-code)